### PR TITLE
MIN/MAX/SWAP macros wrapped in #ifndef blocks

### DIFF
--- a/src/ext/handy.h
+++ b/src/ext/handy.h
@@ -13,22 +13,28 @@
 #define ARRAYCOUNT(arr) (sizeof arr / sizeof arr[0])
 
 /* Normal MIN/MAX macros.  Evaluate argument expressions only once. */
-#define MIN(x, y) \
-  ({ typeof (x) __x = (x); \
-     typeof (y) __y = (y); \
-     __x < __y ? __x : __y; })
-#define MAX(x, y) \
-  ({ typeof (x) __x = (x); \
-     typeof (y) __y = (y); \
-     __x > __y ? __x : __y; })
+#ifndef MIN
+  #define MIN(x, y) \
+    ({ typeof (x) __x = (x); \
+       typeof (y) __y = (y); \
+       __x < __y ? __x : __y; })
+#endif
+#ifndef MAX
+  #define MAX(x, y) \
+    ({ typeof (x) __x = (x); \
+       typeof (y) __y = (y); \
+       __x > __y ? __x : __y; })
+#endif
 
 /* Swap two values.  Uses GCC type inference magic. */
-#define SWAP(x, y) \
-  do { \
-    typeof (x) __tmp = (x); \
-    (x) = (y); \
-    (y) = __tmp; \
-  } while (0)
+#ifndef SWAP
+  #define SWAP(x, y) \
+    do { \
+      typeof (x) __tmp = (x); \
+      (x) = (y); \
+      (y) = __tmp; \
+    } while (0)
+#endif
 
 /** Stringify its argument. */
 #define STRINGIFY(x) STRINGIFY_(x)


### PR DESCRIPTION
Hi,
In the [handy.h](https://github.com/ctz/cifra/blob/master/src/ext/handy.h) header you define some macros that are common and might have been defined in some other place. I wrapped them in #ifndef/#endif blocks.
